### PR TITLE
[CFM_237] Update FridgeInformation Component Responsiveness for Desktop

### DIFF
--- a/src/components/molecules/FridgeInformation/FridgeInformation.jsx
+++ b/src/components/molecules/FridgeInformation/FridgeInformation.jsx
@@ -132,42 +132,27 @@ InformationLine.propTypes = {
 function ImageContainer({ src = null, alt, isAboveFold = false }) {
   if (src) {
     return (
-      <>
-        <Box
-          sx={{
-            display: { xs: 'block', sm: 'none' },
-            width: '100%',
-          }}
-        >
-          <Image
-            src={src}
-            alt={alt}
-            width="100%"
-            height="100%"
-            layout="responsive"
-            objectFit="contain"
-            priority={isAboveFold}
-          />
-        </Box>
-        <Stack
-          direction="row"
-          justifyContent="center"
-          sx={{
-            display: { xs: 'none', sm: 'inherit' },
-            width: '100%',
-          }}
-        >
-          <Image
-            src={src}
-            alt={alt}
-            width="300px"
-            height="345px"
-            layout="fixed"
-            objectFit="contain"
-            priority={isAboveFold}
-          />
-        </Stack>
-      </>
+      <Box
+        sx={{
+          position: 'relative',
+          width: '100%',
+          maxHeight: { xs: 300, md: 345 },
+          aspectRatio: '1 / 1.15',
+          display: 'flex',
+          justifyContent: 'center',
+          backgroundColor: '#F5F5F5',
+          borderRadius: 3,
+          overflow: 'hidden',
+        }}
+      >
+        <Image
+          src={src}
+          alt={alt}
+          layout="fill"
+          objectFit="contain"
+          priority={isAboveFold}
+        />
+      </Box>
     );
   } else return null;
 }
@@ -391,17 +376,27 @@ ReportContainer.propTypes = {
 
 export default function FridgeInformation({ fridge, report }) {
   return (
-    <Stack direction="column" spacing={5} mx={4} mb={4}>
-      {FridgeContainer({ fridge })}
-      {ReportContainer({ report })}
+    <Box
+      sx={{
+        width: '100%',
+        maxWidth: { md: 900 },
+        mx: 'auto',
+        px: { xs: 4, sm: 6 },
+        mb: 4,
+      }}
+    >
+      <Stack direction="column" spacing={5}>
+        {FridgeContainer({ fridge })}
+        {ReportContainer({ report })}
 
-      <ButtonLink
-        aria-label="Click to report the status of the fridge"
-        variant="contained"
-        to={`/user/fridge/report/${fridge.id}`}
-        title="Update Status"
-      />
-    </Stack>
+        <ButtonLink
+          aria-label="Click to report the status of the fridge"
+          variant="contained"
+          to={`/user/fridge/report/${fridge.id}`}
+          title="Update Status"
+        />
+      </Stack>
+    </Box>
   );
 }
 FridgeInformation.propTypes = {


### PR DESCRIPTION
Trello Ticket: https://trello.com/c/Xh6TDW59/287-cfm237-add-max-width-for-desktop-view-of-fridgeinformation-component

- Constrain FridgeInformation Component to 900px on desktop (md) with centered alignment
- Simplify image to single responsive component with dynamic height
- Add rounded gray background

### Testing Responsiveness
https://github.com/user-attachments/assets/56559c4d-3969-4963-bc33-c179c81e0d69

### Sanity Check - Buttons Still Work
https://github.com/user-attachments/assets/37318fe8-f118-48b9-a7ea-e8380e8031c2

### Screenshot of Desktop Display
<img width="1920" height="1075" alt="Screenshot 2026-02-10 at 7 42 52 PM" src="https://github.com/user-attachments/assets/48a80477-f43f-449c-84ea-bf738a4305bf" />


