### PR TITLE
[CFM_238] Update About Page & Image Responsiveness for Desktop

### DIFF
--- a/src/components/atoms/PamphletParagraph/PamphletParagraph.jsx
+++ b/src/components/atoms/PamphletParagraph/PamphletParagraph.jsx
@@ -19,7 +19,7 @@ function ResponsiveImage({ src, alt = '', attribution = null }) {
           position: 'relative',
           width: '100%',
           aspectRatio: '3 / 2',
-          height: { xs: 200, sm: 500, lg: 1200 },
+          height: { xs: 200, sm: 400, lg: 500 },
         }}
       >
         <Image

--- a/src/pages/pamphlet/about.page.jsx
+++ b/src/pages/pamphlet/about.page.jsx
@@ -1,4 +1,5 @@
 import Head from 'next/head';
+import { Box } from '@mui/material';
 import { PamphletParagraph, PageFooter } from 'components/atoms';
 
 const pageContent = {
@@ -78,13 +79,22 @@ export default function AboutPage() {
       <Head>
         <title>Fridge Finder: About Us</title>
       </Head>
-      {content.map((paragraph, index) => (
-        <PamphletParagraph
-          {...paragraph}
-          key={index + '_AboutPage'}
-          hasDivider={index > 0}
-        />
-      ))}
+      <Box
+        sx={{
+          width: '100%',
+          maxWidth: { md: 900, lg: 1100 },
+          mx: 'auto',
+          px: { sm: 6 },
+        }}
+      >
+        {content.map((paragraph, index) => (
+          <PamphletParagraph
+            {...paragraph}
+            key={index + '_AboutPage'}
+            hasDivider={index > 0}
+          />
+        ))}
+      </Box>
 
       <PageFooter />
     </>


### PR DESCRIPTION
Trello Ticket: https://trello.com/c/AAMp7ORU/288-cfm238-update-about-page-desktop-responsive-size

- Decrease Max Image Height to 500px for lg in **ResponsiveImage**
- Set Max Width of AboutPage to 900px for md, and 1100px for lg in **AboutPage**

Responsive Test:

https://github.com/user-attachments/assets/68d3e16e-dfd4-48af-95cb-0ecd504b1c90

